### PR TITLE
Bump upper bound on `base` to accomodate GHC HEAD-to-become-7.10

### DIFF
--- a/terminfo.cabal
+++ b/terminfo.cabal
@@ -29,7 +29,7 @@ Library
     other-extensions: CPP, DeriveDataTypeable, FlexibleInstances, ScopedTypeVariables
     if impl(ghc>=7.3)
       other-extensions: Safe, Trustworthy
-    build-depends:    base >= 4.3 && < 4.8
+    build-depends:    base >= 4.3 && < 4.9
     ghc-options:      -Wall
     exposed-modules:
                     System.Console.Terminfo


### PR DESCRIPTION
base needed a major version bump due to AMP landing
