### PR TITLE
Canonicalise Monad instance

### DIFF
--- a/System/Console/Terminfo/Base.hs
+++ b/System/Console/Terminfo/Base.hs
@@ -198,11 +198,11 @@ instance Functor Capability where
     fmap f (Capability g) = Capability $ \t -> fmap (fmap f) (g t)
 
 instance Applicative Capability where
-    pure  = return
+    pure = Capability . const . pure . Just
     (<*>) = ap
 
 instance Monad Capability where
-    return = Capability . const . return . Just
+    return = pure
     Capability f >>= g = Capability $ \t -> do
         mx <- f t
         case mx of


### PR DESCRIPTION
This refactors the Monad instance of `Capability` into the recommended
canonical form and makes the code a bit more future proof.