### PR TITLE
Define missing Semigroup instance

### DIFF
--- a/System/Console/Terminfo/Base.hs
+++ b/System/Console/Terminfo/Base.hs
@@ -45,7 +45,9 @@ module System.Console.Terminfo.Base(
 
 import Control.Applicative
 import Control.Monad
-#if !MIN_VERSION_base(4,8,0)
+#if MIN_VERSION_base(4,9,0)
+import Data.Semigroup
+#elif !MIN_VERSION_base(4,8,0)
 import Data.Monoid
 #endif
 import Foreign.C
@@ -140,9 +142,18 @@ newtype TermOutput = TermOutput ([TermOutputType] -> [TermOutputType])
 data TermOutputType = TOCmd LinesAffected String
                     | TOStr String
 
+#if MIN_VERSION_base(4,9,0)
+instance Semigroup TermOutput where
+    TermOutput xs <> TermOutput ys = TermOutput (xs . ys)
+
+instance Monoid TermOutput where
+    mempty  = TermOutput id
+    mappend = (<>)
+#else
 instance Monoid TermOutput where
     mempty = TermOutput id
     TermOutput xs `mappend` TermOutput ys = TermOutput (xs . ys)
+#endif
 
 termText :: String -> TermOutput 
 termText str = TermOutput (TOStr str :)


### PR DESCRIPTION
This makes `terminfo` `-Wcompat`-clean.