### PR TITLE
Added a function to convert a TermOutput to a plain String

### DIFF
--- a/System/Console/Terminfo/Base.hs
+++ b/System/Console/Terminfo/Base.hs
@@ -34,6 +34,7 @@ module System.Console.Terminfo.Base(
                             TermOutput(),
                             runTermOutput,
                             hRunTermOutput,
+                            termOutputString,
                             termText,
                             tiGetOutput,
                             LinesAffected,
@@ -161,6 +162,10 @@ termText str = TermOutput (TOStr str :)
 -- | Write the terminal output to the standard output device.
 runTermOutput :: Terminal -> TermOutput -> IO ()
 runTermOutput = hRunTermOutput stdout
+
+-- | Converts a TermOutput back into a plain String (for serialization purposes)
+termOutputString :: TermOutput -> String
+termOutputString (TermOutput to) = concat [case x of TOCmd _ s -> s; TOStr s -> s | x <- to []]
 
 -- | Write the terminal output to the terminal or file managed by the given
 -- 'Handle'.


### PR DESCRIPTION
I know there are functions to write a TermOutput to a Handle, but if you need to perform additional operations before it is written (for example, encrypting it before sending it through the network), then those functions don't give you enough to work with. 

I suppose there could be a way to create a dummy "local" Handle, and write a TermOutput to that Handle to get a String back, but it's  not the most elegant way of achieving a conversion between pure datatypes, especially since it will involve some useless conversion to and from UTF-8 (and using unsafePerformIO).

Thank you for your time,
