### PR TITLE
Explain why del_curterm is missing

### DIFF
--- a/System/Console/Terminfo/Base.hs
+++ b/System/Console/Terminfo/Base.hs
@@ -63,6 +63,9 @@ import Data.Typeable
 
 
 data TERMINAL
+
+-- | 'Terminal' objects are automatically freed by the garbage collector.
+--   Hence, there is no equivalent of @del_curterm@ here.
 newtype Terminal = Terminal (ForeignPtr TERMINAL)
 
 -- Use "unsafe" to make set_curterm faster since it's called quite a bit.


### PR DESCRIPTION
This should hopefully soothe users of the library who would otherwise be frightened by the notable lack of `del_curterm`.