### PR TITLE
Look in ncurses/ for ncurses headers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,14 +29,17 @@ AC_ARG_WITH([cc],
             [CC=$withval])
 AC_PROG_CC()
 
-AC_CHECK_HEADER(ncurses.h, CursesIncludes='ncurses.h',
-    [AC_CHECK_HEADER(curses.h, CursesIncludes='curses.h', HaveCursesH=NO)])
+AC_CHECK_HEADER(ncurses.h, TERMINFO_INCLUDES='ncurses.h term.h',
+    [AC_CHECK_HEADER(curses.h, TERMINFO_INCLUDES='curses.h term.h',
+        [AC_CHECK_HEADER(ncurses/ncurses.h, TERMINFO_INCLUDES='ncurses/ncurses.h ncurses/term.h',
+            [AC_CHECK_HEADER(ncurses/curses.h, TERMINFO_INCLUDES='ncurses/curses.h ncurses/term.h', HaveCursesH=NO)]
+        )]
+    )]
+)
 
 # on Solaris, curses.h must be imported before term.h.
 if test "x$HaveCursesH" = xNO ; then
     AC_MSG_FAILURE([curses headers could not be found, so this package cannot be built])
-else
-    TERMINFO_INCLUDES="$CursesIncludes term.h"
 fi
 
 AC_CHECK_LIB(tinfo, setupterm, HaveLibCurses=YES; LibCurses=tinfo,


### PR DESCRIPTION
DragonflyBSD installs `ncurses.h` as `/usr/local/include/ncurses.h`.
Moreover, ncurses.h refers to `ncurses/ncurses_dll.h`. Consequently, it is
necessary to compile with `--with-curses-includes=/usr/local/include` and
teach configure to look for `ncurses.h` in `ncurses/`

This appears to be what the `AX_WITH_CURSES` recipe does (<https://www.gnu.org/software/autoconf-archive/ax_with_curses.html>).