### PR TITLE
Remove the configure logic around detecting (n)curses.h.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,11 +1,5 @@
 AC_INIT([Haskell terminfo package], [0.2], [judah dot jacobson at gmail dot com], [terminfo])
 
-AC_ARG_WITH([curses-includes],
-  [AC_HELP_STRING([--with-curses-includes],
-    [directory containing curses.h])],
-    [curses_includes=$withval],
-    [curses_includes=NONE])
-
 AC_ARG_WITH([curses-libraries],
   [AC_HELP_STRING([--with-curses-libraries],
     [directory containing curses library])],
@@ -13,31 +7,16 @@ AC_ARG_WITH([curses-libraries],
     [curses_libraries=NONE])
 
 
-TERMINFO_INCLUDE_DIRS=
 TERMINFO_LIB_DIRS=
 if test "x$curses_libraries" != "xNONE"; then
   LDFLAGS="-L$curses_libraries $LDFLAGS"
   TERMINFO_LIB_DIRS=$curses_libraries
-fi
-if test "x$curses_includes" != "xNONE"; then
-  CPPFLAGS="-I$curses_includes $CPPFLAGS"
-  TERMINFO_INCLUDE_DIRS=$curses_includes
 fi
 
 AC_ARG_WITH([cc],
             [C compiler],
             [CC=$withval])
 AC_PROG_CC()
-
-AC_CHECK_HEADER(ncurses.h, CursesIncludes='ncurses.h',
-    [AC_CHECK_HEADER(curses.h, CursesIncludes='curses.h', HaveCursesH=NO)])
-
-# on Solaris, curses.h must be imported before term.h.
-if test "x$HaveCursesH" = xNO ; then
-    AC_MSG_FAILURE([curses headers could not be found, so this package cannot be built])
-else
-    TERMINFO_INCLUDES="$CursesIncludes term.h"
-fi
 
 AC_CHECK_LIB(tinfo, setupterm, HaveLibCurses=YES; LibCurses=tinfo,
   [AC_CHECK_LIB(ncursesw, setupterm, HaveLibCurses=YES; LibCurses=ncursesw,
@@ -52,8 +31,6 @@ else
 fi
 
 
-AC_SUBST(TERMINFO_INCLUDES)
-AC_SUBST(TERMINFO_INCLUDE_DIRS)
 AC_SUBST(TERMINFO_LIB_DIRS)
 AC_SUBST(TERMINFO_LIB)
 

--- a/terminfo.buildinfo.in
+++ b/terminfo.buildinfo.in
@@ -1,4 +1,2 @@
-includes: @TERMINFO_INCLUDES@
-include-dirs: @TERMINFO_INCLUDE_DIRS@
 extra-lib-dirs: @TERMINFO_LIB_DIRS@
 extra-libraries: @TERMINFO_LIB@


### PR DESCRIPTION
It's complicated (see e.g. PR #21), and we don't actually need it for the
build.