### PR TITLE
Mention non-thread-safe nature of ncurses

### DIFF
--- a/System/Console/Terminfo/Base.hs
+++ b/System/Console/Terminfo/Base.hs
@@ -70,6 +70,10 @@ foreign import ccall setupterm :: CString -> CInt -> Ptr CInt -> IO ()
 -- | Initialize the terminfo library to the given terminal entry.
 -- 
 -- Throws a 'SetupTermError' if the terminfo database could not be read.
+--
+-- *Note:* @ncurses@ is not thread-safe; initializing or using multiple
+-- 'Terminal's in different threads at the same time can result in memory
+-- unsafety.
 setupTerm :: String -> IO Terminal
 setupTerm term =
     withCString term $ \c_term ->


### PR DESCRIPTION
As noted in [GHC #17922](https://gitlab.haskell.org/ghc/ghc/issues/17922).