### PR TITLE
Fix calls to varargs C function tparm

### DIFF
--- a/System/Console/Terminfo/Base.hs
+++ b/System/Console/Terminfo/Base.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -263,8 +264,8 @@ tiGetStr cap = Capability $ const $ do
 
 
                     
-foreign import ccall tparm ::
-    CString -> CLong -> CLong -> CLong -> CLong -> CLong -> CLong 
+foreign import capi "term.h tparm"
+    tparm :: CString -> CLong -> CLong -> CLong -> CLong -> CLong -> CLong
     -> CLong -> CLong -> CLong -- p1,...,p9
     -> IO CString
 


### PR DESCRIPTION
The ccall calling convention doesn't support varargs functions, so
switch to capi instead. See
https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/ffi.html#varargs-not-supported-by-ccall-calling-convention