### PR TITLE
Bump bounds to accomodate base-4.18

### DIFF
--- a/terminfo.cabal
+++ b/terminfo.cabal
@@ -28,7 +28,7 @@ Library
     other-extensions: CPP, DeriveDataTypeable, FlexibleInstances, ScopedTypeVariables
     if impl(ghc>=7.3)
       other-extensions: Safe, Trustworthy
-    build-depends:    base >= 4.9 && < 4.18
+    build-depends:    base >= 4.9 && < 4.19
     ghc-options:      -Wall
     exposed-modules:
                     System.Console.Terminfo


### PR DESCRIPTION
In service of GHC 9.6.1.