### PR TITLE
Remove == bashism in favor of posix compliancy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ if test "x$curses_libraries" != "xNONE"; then
   TERMINFO_LIB_DIRS=$curses_libraries
 fi
 
-if test "x$curses_library" == "xNONE"; then
+if test "x$curses_library" = "xNONE"; then
 AC_PROG_CC()
 
 AC_CHECK_LIB(tinfow, setupterm, HaveLibCurses=YES; LibCurses=tinfow,


### PR DESCRIPTION
This commit removes an unnecessary `==` in favor of the more general `=` in order to work with purely posix compliant shells such as `dash`.

This change does not affect the bash shell.