### PR TITLE
Compatibility with GHC 9.12, 9.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ config.log
 config.status
 configure
 dist-install
+dist-newstyle
 ghc.mk
 terminfo.buildinfo

--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,9 @@
 # Changelog of `terminfo`
 
+## Changed in version 0.4.1.7:
+
+- Fix POSIX compliance issue in `configure` script
+
 ## Changed in version 0.4.1.6:
 
 - Minor documentation fixes

--- a/terminfo.cabal
+++ b/terminfo.cabal
@@ -1,6 +1,6 @@
 Name:           terminfo
 Cabal-Version:  >=1.10
-Version:        0.4.1.6
+Version:        0.4.1.7
 Category:       User Interfaces
 License:        BSD3
 License-File:   LICENSE

--- a/terminfo.cabal
+++ b/terminfo.cabal
@@ -28,7 +28,7 @@ Library
     other-extensions: CPP, DeriveDataTypeable, FlexibleInstances, ScopedTypeVariables
     if impl(ghc>=7.3)
       other-extensions: Safe, Trustworthy
-    build-depends:    base >= 4.9 && < 4.21
+    build-depends:    base >= 4.9 && < 4.22
     ghc-options:      -Wall
     exposed-modules:
                     System.Console.Terminfo

--- a/terminfo.cabal
+++ b/terminfo.cabal
@@ -28,7 +28,7 @@ Library
     other-extensions: CPP, DeriveDataTypeable, FlexibleInstances, ScopedTypeVariables
     if impl(ghc>=7.3)
       other-extensions: Safe, Trustworthy
-    build-depends:    base >= 4.9 && < 4.22
+    build-depends:    base >= 4.9 && < 4.23
     ghc-options:      -Wall
     exposed-modules:
                     System.Console.Terminfo


### PR DESCRIPTION
The 9.12 bump is already present on Hackage as a revision. The 9.14 bump will need to be pushed once 9.14 is released.